### PR TITLE
Updated jsdocs: Array -> TemplateStringsArray

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ var concat = require('lineup-stream')
  * Tagged template transforming string into
  * stream.
  *
- * @param {Array} arr
+ * @param {TemplateStringsArray} arr
  * @api public
  */
 


### PR DESCRIPTION
Right now, VSCode complains about it when using `"javascript.implicitProjectConfig.checkJs": true`. This PR solves that.
